### PR TITLE
Changing affection status parser

### DIFF
--- a/gelweb/gel2mdt/database_utils/case_handler.py
+++ b/gelweb/gel2mdt/database_utils/case_handler.py
@@ -199,10 +199,12 @@ class Case(object):
                         continue
                     family_member = {'gel_id': participant["gelId"],
                                      'relation_to_proband': participant["additionalInformation"]["relation_to_proband"],
-                                     'affection_status': participant["affectionStatus"],
+                                     'affection_status': False,
                                      'sequenced': False,
                                      'sex': participant['sex'],
                                      }
+                    if len(participant['disorderList'] > 0):
+                        family_member['affection_status'] = True
 
                     # determine if participant has undergone sequencing for trio
                     # calc


### PR DESCRIPTION
There is an issue identified whereby the affectionStatus does not populate correctly. It is not used in analysis so this field is not validated and should be ignored.