### PR TITLE
Updates to allow use with mod_wsgi-express

### DIFF
--- a/gelweb/gelweb/settings/base.py
+++ b/gelweb/gelweb/settings/base.py
@@ -25,11 +25,11 @@ except ImportError:
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-STATIC_DIR = os.path.join(BASE_DIR, 'static')
-STATIC_ROOT = os.path.join(BASE_DIR, 'static_files')
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATIC_DIR = os.path.join(BASE_DIR, 'gelweb/static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'gelweb/static_files')
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
+    os.path.join(BASE_DIR, 'gelweb/static'),
 )
 
 # Quick-start development settings - unsuitable for production

--- a/gelweb/gelweb/settings/base.py
+++ b/gelweb/gelweb/settings/base.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 # Check that the expected local_settings values are present
 try:
-    from .local_settings import SECRET_KEY, DEBUG, ALLOWED_HOSTS, DATABASES
+    from .local_settings import SECRET_KEY, DEBUG, ALLOWED_HOSTS, DATABASES, ADDITIONAL_APPS
 except ImportError:
     print('Check the following settings are present in local_settings.py:\n'
           'SECRET_KEY, DEBUG, ALLOWED_HOSTS, DATABASES')
@@ -31,6 +31,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static_files')
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
@@ -50,7 +51,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'easy_pdf'
-]
+] + ADDITIONAL_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/gelweb/gelweb/settings/example_local_settings.py
+++ b/gelweb/gelweb/settings/example_local_settings.py
@@ -10,6 +10,9 @@ DEBUG = True
 ALLOWED_HOSTS = ['localhost',
                  '127.0.0.1']
 
+# Any addtional installed Django apps for inclusion in settings (e.g. 'mod_wsgi.server')
+ADDITIONAL_APPS = []
+
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 


### PR DESCRIPTION
Added option to include additional installed apps in the local_settings file (For us this allows us to include the mod_wsgi.server module used to serve using mod_wsgi-express)

mod_wsgi-express requires BASE_DIR in the settings file to point to the directory containing `manage.py`, I've updated BASE_DIR to point one level higher and modified all references to BASE_DIR to point to `gelweb/...` so they still point to the same location. Hope this doesn't cause any issues with other setups???

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nhs-ngs/gel2mdt/124)
<!-- Reviewable:end -->
